### PR TITLE
Support multi-answer submissions in download output

### DIFF
--- a/R/write_answers.R
+++ b/R/write_answers.R
@@ -64,8 +64,11 @@ write_answers <- function(file, session, is_test = FALSE){
                         .default = NA),
     submission_type = purrr::map_chr(objs, "type",
                                      .default = NA),
-    answer = purrr::map_chr(objs, "answer",
-                            .default = NA)
+    answer = purrr::map_chr(
+      objs, 
+      ~ if (length(.x$answer) > 1) paste(.x$answer, collapse = ", ") else as.character(.x$answer),
+      .default = NA
+    )
   )
 
   # Hacky


### PR DESCRIPTION
This PR extends the answer export logic to handle submissions with multiple answers.
Previously, answers from drag-and-drop questions created with [sortable](https://github.com/rstudio/sortable) could not be exported. Clicking the download button in a tutorial containing sortable questions caused this error: 

Error in purrr::map_chr: 
ℹ In index: 5.
ℹ With name: drag_and_drop_code.
Caused by error:
! Result must be length 1, not 5.. 

Now, multiple answers are joined as a comma-separated string. Below is a screenshot of the HTML export for a tutorial that contains a sortable drag-and-drop question: 

![sample_html_output](https://github.com/user-attachments/assets/c4c5921f-98dd-422d-bdeb-0cf9cf68d59c)


