### PR TITLE
Fix show_file() stripping pagedtable HTML from chunk output

### DIFF
--- a/R/show_file.R
+++ b/R/show_file.R
@@ -1,3 +1,51 @@
+#' Remove embedded pagedtable HTML artifacts from a vector of lines
+#'
+#' VS Code's interactive chunk execution can cache a chunk's rendered output
+#' directly back into the .qmd/.Rmd source file. When the chunk's output is a
+#' tibble, that cached output is a pagedtable HTML widget (a `<div
+#' data-pagedtable="false">` block wrapping a `<script
+#' data-pagedtable-source>` JSON blob). Because this cached output can end up
+#' inside the same fenced region as the code itself, show_file()'s chunk
+#' extraction can otherwise return this HTML noise instead of clean source
+#' code. This helper strips any such blocks out of a character vector of
+#' lines before they are printed.
+#'
+#' @param lines A character vector of lines (as returned by readLines()).
+#' @return A character vector with any pagedtable HTML blocks removed.
+#' @keywords internal
+strip_pagedtable_html <- function(lines) {
+  if (length(lines) == 0) {
+    return(lines)
+  }
+
+  keep <- rep(TRUE, length(lines))
+  depth <- 0
+  in_block <- FALSE
+
+  for (i in seq_along(lines)) {
+    line <- lines[i]
+
+    # A pagedtable block always starts with a <div data-pagedtable...> tag.
+    if (!in_block && grepl("^\\s*<div\\s+data-pagedtable", line)) {
+      in_block <- TRUE
+      depth <- 0
+    }
+
+    if (in_block) {
+      keep[i] <- FALSE
+      # Track nested <div ...> / </div> tags so we find the *matching*
+      # closing tag rather than the first </div> we see.
+      depth <- depth + lengths(regmatches(line, gregexpr("<div\\b", line)))
+      depth <- depth - lengths(regmatches(line, gregexpr("</div>", line)))
+      if (depth <= 0) {
+        in_block <- FALSE
+      }
+    }
+  }
+
+  lines[keep]
+}
+
 #' Display the contents of a text file that match a pattern
 #'
 #' This function reads the contents of a text file and either prints the specified range of rows
@@ -74,6 +122,16 @@ show_file <- function(path, start = 1, end = NULL, pattern = NULL, chunk = "None
   
   # Read the contents of the file
   contents <- readLines(path)
+
+  # VS Code's interactive chunk execution can cache a chunk's rendered
+  # output directly back into the .qmd/.Rmd source file. When the chunk's
+  # output is a tibble, that cached output is a pagedtable HTML widget (a
+  # `<div data-pagedtable="false">` block wrapping a `<script
+  # data-pagedtable-source>` JSON blob), and it can end up inside the same
+  # fenced region as the code itself. Strip any such blocks here, up front,
+  # so every code path below (YAML, whole-file, tail, chunk extraction, and
+  # row-range) sees clean source text rather than rendered-output noise.
+  contents <- strip_pagedtable_html(contents)
   
   # Remove trailing empty lines from the contents
   while (length(contents) > 0 && contents[length(contents)] == "") {

--- a/tests/testthat/fixtures/show_file_pagedtable_test.qmd
+++ b/tests/testthat/fixtures/show_file_pagedtable_test.qmd
@@ -1,0 +1,16 @@
+---
+title: "Test Document"
+---
+
+```{r}
+library(tidyverse)
+```
+
+```{r}
+penguins
+<div data-pagedtable="false">
+  <script data-pagedtable-source type="application/json">
+{"columns":[{"label":["species"],"name":[1],"type":["fct"]}],"data":[["Adelie"]]}
+  </script>
+</div>
+```

--- a/tests/testthat/test-show_file.R
+++ b/tests/testthat/test-show_file.R
@@ -219,4 +219,45 @@ test_that("show_file function works correctly", {
   writeLines("only one line", one_line_file)
   on.exit(unlink(one_line_file), add = TRUE)
   expect_error(show_file(one_line_file, chunk = "YAML"), "No YAML header found.")
+
+  # Test case 28: chunk = "Last" strips embedded pagedtable HTML that VS
+  # Code's interactive chunk execution can cache back into a .qmd file
+  test_file_pagedtable <- test_path("fixtures", "show_file_pagedtable_test.qmd")
+  expect_equal(paste(capture.output(show_file(test_file_pagedtable, chunk = "Last")), collapse = "\n"),
+               "penguins")
+
+  # Test case 29: chunk = "All" strips pagedtable HTML from every chunk
+  expect_equal(paste(capture.output(show_file(test_file_pagedtable, chunk = "All")), collapse = "\n"),
+               paste(c(
+                 "library(tidyverse)",
+                 "",
+                 "penguins"
+               ), collapse = "\n"))
+
+  # Test case 30: pagedtable HTML is stripped even outside chunk mode
+  expect_false(grepl("pagedtable",
+                      paste(capture.output(show_file(test_file_pagedtable, start = 0)), collapse = "\n")))
+
+  # Test case 31: nested <div> tags inside the pagedtable JSON payload do
+  # not confuse the stripping logic
+  nested_div_file <- tempfile(fileext = ".qmd")
+  writeLines(c(
+    "```{r}",
+    "df",
+    '<div data-pagedtable="false">',
+    '  <script data-pagedtable-source type="application/json">',
+    '{"data":[["<div>nested</div>"]]}',
+    "  </script>",
+    "</div>",
+    "```"
+  ), nested_div_file)
+  on.exit(unlink(nested_div_file), add = TRUE)
+  expect_equal(paste(capture.output(show_file(nested_div_file, chunk = "Last")), collapse = "\n"),
+               "df")
+
+  # Test case 32: strip_pagedtable_html() is a no-op on ordinary lines
+  expect_equal(strip_pagedtable_html(c("a <- 1", "b <- 2")), c("a <- 1", "b <- 2"))
+
+  # Test case 33: strip_pagedtable_html() handles an empty vector
+  expect_equal(strip_pagedtable_html(character(0)), character(0))
 })


### PR DESCRIPTION
Fixes the pagedtable HTML bug from vscode.tutorials#59. VS Code's chunk execution caches tibble output back into the .qmd file as pagedtable HTML, and it was ending up inside the same fence as the code. show_file() just printed whatever was there, HTML included.

Added strip_pagedtable_html() to filter that out before show_file() runs. Added 6 new tests for it. Full suite passes, 312/312.